### PR TITLE
Fix for Issue: Automatic Installation of Python Dependencies

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -17,7 +17,7 @@ end
 
 function pip(pkgname)
    checkpip()
-   pipcmd = `$(PyCall.pyprogramname[1:end-6])pip install --upgrade --user $(pkgname)`
+   pipcmd = `$(PyCall.python) -m pip install --upgrade --user $(pkgname)`
    run(`$(pipcmd)`)
 end
 

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -3,7 +3,8 @@ using PyCall
 function checkpip()
    # Import pip
    try
-       @pyimport pip
+      pipver = `$(PyCall.python) -m pip --version`
+      run(`$(pipver)`)
    catch
        # If it is not found, install it
        println("""I couldn't find `pip`. I will try to download and install it

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,6 +7,7 @@ println(" Testing ASE.jl")
 println("-------------------")
 
 @testset "ASE" begin
+   @testset "Build" begin include("test_build.jl"); end
    @testset "Atoms"  begin include("testase.jl"); end
    @testset "Calculators" begin include("test_calculators.jl"); end
 end

--- a/test/test_build.jl
+++ b/test/test_build.jl
@@ -1,0 +1,6 @@
+using PyCall
+
+include("../deps/build.jl")
+
+println("Test Dependency Build")
+@test pip("pip") == nothing


### PR DESCRIPTION
[Issue](https://github.com/libAtoms/ASE.jl/issues/1)

using `$(PyCall.python) -m pip install --upgrade --user $(pkgname)`, solves the build issue of it trying to find pip in some path. This now invokes pip via the python being used by PyCall.

Added a test for the `function pip()` which checks if the package 'pip' exist; as if pip is installed, the package `pip` already exists so the test should not download anything.