### PR TITLE
fixing missing LinearAlgebra dependency

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,6 +8,7 @@ NeighbourLists = "2fcf5ba9-9ed4-57cf-b73f-ff513e316b9c"
 Parameters = "d96e819e-fc66-5662-9728-84c9c7592b0a"
 PyCall = "438e738f-606a-5dbb-bf0a-cddfbfd45ab0"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 
 [compat]
 julia = "0.7, 1"

--- a/src/ASE.jl
+++ b/src/ASE.jl
@@ -1,5 +1,5 @@
 
-__precompile__()
+__precompile__(false)
 
 module ASE
 

--- a/src/ASE.jl
+++ b/src/ASE.jl
@@ -1,5 +1,5 @@
 
-__precompile__(false)
+__precompile__()
 
 module ASE
 


### PR DESCRIPTION
LinearAlgebra was missing from the dependencies which caused the following warning: 
```
julia> using ASE
[ Info: Precompiling ASE [51974c44-a7ed-5088-b8be-3e78c8ba416c]
┌ Warning: Package ASE does not have LinearAlgebra in its dependencies:
│ - If you have ASE checked out for development and have
│   added LinearAlgebra as a dependency but haven't updated your primary
│   environment's manifest file, try `Pkg.resolve()`.
│ - Otherwise you may need to report an issue with ASE
└ Loading LinearAlgebra into ASE from project dependency, future warnings for ASE are suppressed.
```