### PR TITLE
Update build status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 Julia Bindings for the [Atomic Simulation Environment (ASE)](https://wiki.fysik.dtu.dk/ase/)
 
-[![Build Status](https://travis-ci.org/libAtoms/ASE.jl.svg?branch=master)](https://travis-ci.org/libAtoms/ASE.jl)
+[![Build Status](https://travis-ci.org/JuliaMolSim/ASE.jl.svg?branch=master)](https://travis-ci.org/JuliaMolSim/ASE.jl)
 
 ### Summary
 


### PR DESCRIPTION
The build status badge on the README was not working because it was using the old `libAtoms` name.